### PR TITLE
Update variables.tf with availability domains based on region

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,14 @@
 output "instance_id" {
   description = "ocid of created instances. "
-  value       = ["${oci_core_instance.wirehole_instance.id}"]
+  value       = [oci_core_instance.wirehole_instance.id]
 }
 
 output "private_ip" {
   description = "Private IPs of created instances. "
-  value       = ["${oci_core_instance.wirehole_instance.private_ip}"]
+  value       = [oci_core_instance.wirehole_instance.private_ip]
 }
 
 output "public_ip" {
   description = "Public IPs of created instances. "
-  value       = ["${oci_core_instance.wirehole_instance.public_ip}"]
+  value       = [oci_core_instance.wirehole_instance.public_ip]
 }

--- a/userdata/init.sh
+++ b/userdata/init.sh
@@ -28,4 +28,5 @@ sudo curl -L "https://github.com/docker/compose/releases/download/1.26.2/docker-
 # wirehole
 git clone https://github.com/IAmStoxe/wirehole.git &&
     cd wirehole &&
+    sed -i 's/PEERS=1/PEERS=3/' &&
     docker-compose up

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,13 @@ variable "vcn_cidr_block" {
 }
 
 variable "availability_domain_number" {
-  default = 1
+  type = map(string)
+
+  default = {
+    us-phoenix-1 = 2
+    us-ashburn-1 = 3
+    us-seattle-1 = 2
+  }
 }
 
 variable "instance_shape" {

--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ variable "instance_image_ocid" {
     me-dubai-1     = "ocid1.image.oc1.me-dubai-1.aaaaaaaacc4knywj5cmo544357zb2yn6fabmarv6s3khyny22spuq4edm4iq"
     me-jeddah-1    = "ocid1.image.oc1.me-jeddah-1.aaaaaaaaehhthiygczhamsxpnaebwwuuof4ghuzbhmtl5yfcjzw7af6lwlgq"
     sa-santiago-1  = "ocid1.image.oc1.sa-santiago-1.aaaaaaaaghwg2p3fwtu4q25p5ebg65mf5ncqbikqrepsttnzqrtwzccrdcma"
-    sa-saopaulo-1  = 'ocid1.image.oc1.sa-saopaulo-1.aaaaaaaa2bfgkwh4ajxq573nfzqk6pzcnamhz7yecg7qjwjlstbtkdiaovxq"
+    sa-saopaulo-1  = "ocid1.image.oc1.sa-saopaulo-1.aaaaaaaa2bfgkwh4ajxq573nfzqk6pzcnamhz7yecg7qjwjlstbtkdiaovxq"
     uk-cardiff-1   = "ocid1.image.oc1.uk-cardiff-1.aaaaaaaanivgefpi7h2yap5e2st7setz6bri2pfen2nttwdy3n6eyliknqla"
     uk-london-1    = "ocid1.image.oc1.uk-london-1.aaaaaaaaaqhrhabecnuwgasrfagihh5nqkexc7mq6lwwv5nvsxmu3gajp2ta"
     us-ashburn-1   = "ocid1.image.oc1.iad.aaaaaaaacliktmviofdyzhua77nyur2htmrzwjaxollbfae52q6zfuvkcjdq"

--- a/variables.tf
+++ b/variables.tf
@@ -22,9 +22,28 @@ variable "availability_domain_number" {
   type = map(string)
 
   default = {
-    us-phoenix-1 = 2
-    us-ashburn-1 = 3
-    us-seattle-1 = 2
+    ap-chuncheon-1 = 1
+    ap-hyderabad-1 = 1
+    ap-melbourne-1 = 1
+    ap-mumbai-1    = 1
+    ap-osaka-1     = 1
+    ap-seoul-1     = 1
+    ap-sydney-1    = 1
+    ap-tokyo-1     = 1
+    ca-montreal-1  = 1
+    ca-toronto-1   = 1
+    eu-amsterdam-1 = 1
+    eu-frankfurt-1 = 3
+    eu-zurich-1    = 1
+    me-dubai-1     = 1
+    me-jeddah-1    = 1
+    sa-santiago-1  = 1
+    sa-saopaulo-1  = 1
+    uk-cardiff-1   = 1
+    uk-london-1    = 3
+    us-ashburn-1   = 3
+    us-phoenix-1   = 3
+    us-sanjose-1   = 1
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -19,32 +19,7 @@ variable "vcn_cidr_block" {
 }
 
 variable "availability_domain_number" {
-  type = map(string)
-
-  default = {
-    ap-chuncheon-1 = 1
-    ap-hyderabad-1 = 1
-    ap-melbourne-1 = 1
-    ap-mumbai-1    = 1
-    ap-osaka-1     = 1
-    ap-seoul-1     = 1
-    ap-sydney-1    = 1
-    ap-tokyo-1     = 1
-    ca-montreal-1  = 1
-    ca-toronto-1   = 1
-    eu-amsterdam-1 = 1
-    eu-frankfurt-1 = 3
-    eu-zurich-1    = 1
-    me-dubai-1     = 1
-    me-jeddah-1    = 1
-    sa-santiago-1  = 1
-    sa-saopaulo-1  = 1
-    uk-cardiff-1   = 1
-    uk-london-1    = 3
-    us-ashburn-1   = 3
-    us-phoenix-1   = 3
-    us-sanjose-1   = 1
-  }
+  default = 3
 }
 
 variable "instance_shape" {

--- a/variables.tf
+++ b/variables.tf
@@ -58,30 +58,30 @@ variable "instance_image_ocid" {
   default = {
     # See https://docs.oracle.com/en-us/iaas/images/ubuntu-1804/
     # Oracle-provided image "Canonical-Ubuntu-18.04-2020.12.11-0"
-    ap-chuncheon-1 = ocid1.image.oc1.ap-chuncheon-1.aaaaaaaa4jmnlvf2sb6dkkolhkxo4bmjjrr2w5zfajsz6mra7fdxh2bmibea
-    ap-hyderabad-1 = ocid1.image.oc1.ap-hyderabad-1.aaaaaaaajnru2s5t7haaqcmxrwtis2nicqro5ysp4pvc6izuirs2lepuloza
-    ap-melbourne-1 = ocid1.image.oc1.ap-melbourne-1.aaaaaaaawctcj5y6fbyozezt725azs3cvmlmnrpxghg3ny2dflkeayz2oqla
-    ap-mumbai-1    = ocid1.image.oc1.ap-mumbai-1.aaaaaaaasyycr7ps55lrah6a7a2xxtqifvgarhwuf6u73hwup4zkw7f4kn5a
-    ap-osaka-1     = ocid1.image.oc1.ap-osaka-1.aaaaaaaapenyex5pxfxy6sj3y3giodvcuab3q2ijecseqagxrjkh56nfp3bq
-    ap-seoul-1     = ocid1.image.oc1.ap-seoul-1.aaaaaaaauz3wjiq7cug667vvj7rsghqam7k6ixvq64deiw2suf6mk2iru5eq
-    ap-sydney-1    = ocid1.image.oc1.ap-sydney-1.aaaaaaaabrw3swos5hvtxqfgxu63bnd23hfjq7telribqeiqusxtdazwlwua
-    ap-tokyo-1     = ocid1.image.oc1.ap-tokyo-1.aaaaaaaa3xvdaubabxqrh36zgujjp3gh6c2suul4u4nrchpnvf4hbggwgodq
-    ca-montreal-1  = ocid1.image.oc1.ca-montreal-1.aaaaaaaanrbycrwfxq73bnb4riglp7e67gb6xjatpkke5h2c6pdwcblb7rja
-    ca-toronto-1   = ocid1.image.oc1.ca-toronto-1.aaaaaaaa2mwnn3au2xesuaplssp37bwnym3mb6va6rz5gbfgpxvt3ls6dbqa
-    eu-amsterdam-1 = ocid1.image.oc1.eu-amsterdam-1.aaaaaaaaxaf3xlj46q2jc4e3cdiqrpt3oacavie6ersr766sqafyex2qh5lq
-    eu-frankfurt-1 = ocid1.image.oc1.eu-frankfurt-1.aaaaaaaasso5vqvbonl4ne6lz4ugpazyc6g3gll6pi2kucjxtxt3rul4l3sa
-    eu-zurich-1    = ocid1.image.oc1.eu-zurich-1.aaaaaaaavcfqtutpkkoyoxgmcomcbtlonsd3so2drrbk4hainibyp5ruxnea
-    me-dubai-1     = ocid1.image.oc1.me-dubai-1.aaaaaaaacc4knywj5cmo544357zb2yn6fabmarv6s3khyny22spuq4edm4iq
-    me-jeddah-1    = ocid1.image.oc1.me-jeddah-1.aaaaaaaaehhthiygczhamsxpnaebwwuuof4ghuzbhmtl5yfcjzw7af6lwlgq
-    sa-santiago-1  = ocid1.image.oc1.sa-santiago-1.aaaaaaaaghwg2p3fwtu4q25p5ebg65mf5ncqbikqrepsttnzqrtwzccrdcma
-    sa-saopaulo-1  = ocid1.image.oc1.sa-saopaulo-1.aaaaaaaa2bfgkwh4ajxq573nfzqk6pzcnamhz7yecg7qjwjlstbtkdiaovxq
-    uk-cardiff-1   = ocid1.image.oc1.uk-cardiff-1.aaaaaaaanivgefpi7h2yap5e2st7setz6bri2pfen2nttwdy3n6eyliknqla
-    uk-london-1    = ocid1.image.oc1.uk-london-1.aaaaaaaaaqhrhabecnuwgasrfagihh5nqkexc7mq6lwwv5nvsxmu3gajp2ta
-    us-ashburn-1   = ocid1.image.oc1.iad.aaaaaaaacliktmviofdyzhua77nyur2htmrzwjaxollbfae52q6zfuvkcjdq
-    us-langley-1   = ocid1.image.oc2.us-langley-1.aaaaaaaak5z3civ5tdlntkjivu7bmez5zngg3m6zd24qcfmn43btptzob3lq
-    us-luke-1      = ocid1.image.oc2.us-luke-1.aaaaaaaaq5mfm7tle2a2nnysg3cfngbdqlkelg6rdwmkinqgnkhy7fgzrg6q
-    us-phoenix-1   = ocid1.image.oc1.phx.aaaaaaaaiz72kdaznhk3kynsw4faync6z3ibd3en6vchupnb4vonfsnvizwq
-    us-sanjose-1   = ocid1.image.oc1.us-sanjose-1.aaaaaaaaxyaxpb7mkld7dsoqibdbg2na5npgzkjn3oybqifzmcaki7qewwfq
+    ap-chuncheon-1 = "ocid1.image.oc1.ap-chuncheon-1.aaaaaaaa4jmnlvf2sb6dkkolhkxo4bmjjrr2w5zfajsz6mra7fdxh2bmibea"
+    ap-hyderabad-1 = "ocid1.image.oc1.ap-hyderabad-1.aaaaaaaajnru2s5t7haaqcmxrwtis2nicqro5ysp4pvc6izuirs2lepuloza"
+    ap-melbourne-1 = "ocid1.image.oc1.ap-melbourne-1.aaaaaaaawctcj5y6fbyozezt725azs3cvmlmnrpxghg3ny2dflkeayz2oqla"
+    ap-mumbai-1    = "ocid1.image.oc1.ap-mumbai-1.aaaaaaaasyycr7ps55lrah6a7a2xxtqifvgarhwuf6u73hwup4zkw7f4kn5a"
+    ap-osaka-1     = "ocid1.image.oc1.ap-osaka-1.aaaaaaaapenyex5pxfxy6sj3y3giodvcuab3q2ijecseqagxrjkh56nfp3bq"
+    ap-seoul-1     = "ocid1.image.oc1.ap-seoul-1.aaaaaaaauz3wjiq7cug667vvj7rsghqam7k6ixvq64deiw2suf6mk2iru5eq"
+    ap-sydney-1    = "ocid1.image.oc1.ap-sydney-1.aaaaaaaabrw3swos5hvtxqfgxu63bnd23hfjq7telribqeiqusxtdazwlwua"
+    ap-tokyo-1     = "ocid1.image.oc1.ap-tokyo-1.aaaaaaaa3xvdaubabxqrh36zgujjp3gh6c2suul4u4nrchpnvf4hbggwgodq"
+    ca-montreal-1  = "ocid1.image.oc1.ca-montreal-1.aaaaaaaanrbycrwfxq73bnb4riglp7e67gb6xjatpkke5h2c6pdwcblb7rja"
+    ca-toronto-1   = "ocid1.image.oc1.ca-toronto-1.aaaaaaaa2mwnn3au2xesuaplssp37bwnym3mb6va6rz5gbfgpxvt3ls6dbqa"
+    eu-amsterdam-1 = "ocid1.image.oc1.eu-amsterdam-1.aaaaaaaaxaf3xlj46q2jc4e3cdiqrpt3oacavie6ersr766sqafyex2qh5lq"
+    eu-frankfurt-1 = "ocid1.image.oc1.eu-frankfurt-1.aaaaaaaasso5vqvbonl4ne6lz4ugpazyc6g3gll6pi2kucjxtxt3rul4l3sa"
+    eu-zurich-1    = "ocid1.image.oc1.eu-zurich-1.aaaaaaaavcfqtutpkkoyoxgmcomcbtlonsd3so2drrbk4hainibyp5ruxnea"
+    me-dubai-1     = "ocid1.image.oc1.me-dubai-1.aaaaaaaacc4knywj5cmo544357zb2yn6fabmarv6s3khyny22spuq4edm4iq"
+    me-jeddah-1    = "ocid1.image.oc1.me-jeddah-1.aaaaaaaaehhthiygczhamsxpnaebwwuuof4ghuzbhmtl5yfcjzw7af6lwlgq"
+    sa-santiago-1  = "ocid1.image.oc1.sa-santiago-1.aaaaaaaaghwg2p3fwtu4q25p5ebg65mf5ncqbikqrepsttnzqrtwzccrdcma"
+    sa-saopaulo-1  = 'ocid1.image.oc1.sa-saopaulo-1.aaaaaaaa2bfgkwh4ajxq573nfzqk6pzcnamhz7yecg7qjwjlstbtkdiaovxq"
+    uk-cardiff-1   = "ocid1.image.oc1.uk-cardiff-1.aaaaaaaanivgefpi7h2yap5e2st7setz6bri2pfen2nttwdy3n6eyliknqla"
+    uk-london-1    = "ocid1.image.oc1.uk-london-1.aaaaaaaaaqhrhabecnuwgasrfagihh5nqkexc7mq6lwwv5nvsxmu3gajp2ta"
+    us-ashburn-1   = "ocid1.image.oc1.iad.aaaaaaaacliktmviofdyzhua77nyur2htmrzwjaxollbfae52q6zfuvkcjdq"
+    us-langley-1   = "ocid1.image.oc2.us-langley-1.aaaaaaaak5z3civ5tdlntkjivu7bmez5zngg3m6zd24qcfmn43btptzob3lq"
+    us-luke-1      = "ocid1.image.oc2.us-luke-1.aaaaaaaaq5mfm7tle2a2nnysg3cfngbdqlkelg6rdwmkinqgnkhy7fgzrg6q"
+    us-phoenix-1   = "ocid1.image.oc1.phx.aaaaaaaaiz72kdaznhk3kynsw4faync6z3ibd3en6vchupnb4vonfsnvizwq"
+    us-sanjose-1   = "ocid1.image.oc1.us-sanjose-1.aaaaaaaaxyaxpb7mkld7dsoqibdbg2na5npgzkjn3oybqifzmcaki7qewwfq"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -52,37 +52,36 @@ variable "instance_shape" {
   default = "VM.Standard.E2.1.Micro"
 }
 
-
 variable "instance_image_ocid" {
   type = map
 
   default = {
-    # See https://docs.cloud.oracle.com/en-us/iaas/images/image/cc81a889-bc7f-4b70-b8e7-0503812665be/
-    # Oracle-provided image "Canonical-Ubuntu-20.04-2020.07.16-0"
-    ap-chuncheon-1   = "oci1.image.oc1.ap-chuncheon-1.aaaaaaaanpstj3in2kstrhljuc7gzrvedxbzrgvo5ji5cxogz6tvlm2k5tya"
-    ap-hyderabad-1   = "oci1.image.oc1.ap-hyderabad-1.aaaaaaaatw7enpwfku5corct26rnl5sdo4bw5cpvnowqaieafyoylfwyxswq"
-    ap-melbourne-1   = "oci1.image.oc1.ap-melbourne-1.aaaaaaaa2ja7gvvlzqqbquenqh7ycye5intwkvxja66rm3tevoakrghszfkq"
-    ap-mumbai-1      = "oci1.image.oc1.ap-mumbai-1.aaaaaaaakonst4ow5vbxuk4tvvko3fuhhk4lpupkku7bfthll2axhd7kox4a"
-    ap-osaka-1       = "oci1.image.oc1.ap-osaka-1.aaaaaaaaywaz6zpfz4xgcppodgkosec7r67lcamhnamg66lwgthkybhzn6sa"
-    ap-seoul-1       = "oci1.image.oc1.ap-seoul-1.aaaaaaaacd2rve4fvn5hxktbuhp4qvoulvrmdo7ypoqadidgofeji2cfuxda"
-    ap-sydney-1      = "oci1.image.oc1.ap-sydney-1.aaaaaaaavjkbnlvtn3lbx5sg6xgp5myxo65xgnvylwzgcdvnmenct75bzpaa"
-    ap-tokyo-1       = "oci1.image.oc1.ap-tokyo-1.aaaaaaaawlsp7sss5g3hyzfnu4a2ch54zd3fjp3logs5mi6ufk2hcg6wn4ha"
-    ca-montreal-1    = "oci1.image.oc1.ca-montreal-1.aaaaaaaa5yv2qg3sthtxgvtfixekmwqcfizxwfp5ifnumcbhwscr4cnxg5nq"
-    ca-toronto-1     = "oci1.image.oc1.ca-toronto-1.aaaaaaaaktxtwxrsuuelvwt5bmxm6vmbu66oelief6pbwnstjpo4kuaxm7oa"
-    eu-amsterdam-1   = "oci1.image.oc1.eu-amsterdam-1.aaaaaaaaxkhd2at377qo2cmqz3rtjnacygf67h4l5po27vgpzl4wfdl7kana"
-    eu-frankfurt-1   = "oci1.image.oc1.eu-frankfurt-1.aaaaaaaa33gomi5dzrv7z4atbtpw4wrddstenlrroe3kb6snltkgdi4mv3yq"
-    eu-zurich-1      = "oci1.image.oc1.eu-zurich-1.aaaaaaaagksoyjqxkkvhfwqazowfgwcn65lzxhp4mvw2if3nifdx2tzgt6ma"
-    me-jeddah-1      = "oci1.image.oc1.me-jeddah-1.aaaaaaaay5jjjjj5bv2hh5553oi2ljo7nc36dxhx75sarcecs5ozlu374lja"
-    sa-saopaulo-1    = "oci1.image.oc1.sa-saopaulo-1.aaaaaaaaonwl3zjp6cxf3kbhpyipyufhmyymdimtfelzky6r745zojytab6a"
-    uk-gov-london-1  = "oci1.image.oc4.uk-gov-london-1.aaaaaaaagdq7eit7otaqpbo5tdeh2avqvrszszw3iqojva5kl5ztoxx7ypqa"
-    uk-london-1      = "oci1.image.oc1.uk-london-1.aaaaaaaamnz6jzdyj7yyfeh6vyoydjw4e6eigus6qnwuwh2ugu7agbnnvr5a"
-    us-ashburn-1     = "ocid1.image.oc1.iad.aaaaaaaa4zmhh435fbohrt6cwwomyfkcnrrr3ce2czs2qs52eadlu7mr45va"
-    us-gov-ashburn-1 = "oci1.image.oc3.us-gov-ashburn-1.aaaaaaaask3s2dqo632wkaiwxzzhnrdpfhcdzjc4xu7nos4msasbutd5ct6q"
-    us-gov-chicago-1 = "oci1.image.oc3.us-gov-chicago-1.aaaaaaaadgg6aqmf5daphzbhcimv2hs3gxgaigflkcvmi64wwcqmqa7p3rjq"
-    us-gov-phoenix-1 = "oci1.image.oc3.us-gov-phoenix-1.aaaaaaaalqzdesgljdqnauzgbttxlnpp4ejyrcq5tj4gj36ehnd7xncc6y6q"
-    us-langley-1     = "oci1.image.oc2.us-langley-1.aaaaaaaa2krdwhl7pbjgjbg45ucjzfjxcn4yaesaf25ydtwbyr6noxogx7fa"
-    us-luke-1        = "oci1.image.oc2.us-luke-1.aaaaaaaaqkuvnbqhahsw3dgz76pjirutaluumajwai3rhwzubiuijccna4iq"
-    us-phoenix-1     = "oci1.image.oc1.phx.aaaaaaaagxjw52zc22yyyqtid5737elillsqt2vxokj5wdnvhvswhyol74qq"
+    # See https://docs.oracle.com/en-us/iaas/images/ubuntu-1804/
+    # Oracle-provided image "Canonical-Ubuntu-18.04-2020.12.11-0"
+    ap-chuncheon-1 = ocid1.image.oc1.ap-chuncheon-1.aaaaaaaa4jmnlvf2sb6dkkolhkxo4bmjjrr2w5zfajsz6mra7fdxh2bmibea
+    ap-hyderabad-1 = ocid1.image.oc1.ap-hyderabad-1.aaaaaaaajnru2s5t7haaqcmxrwtis2nicqro5ysp4pvc6izuirs2lepuloza
+    ap-melbourne-1 = ocid1.image.oc1.ap-melbourne-1.aaaaaaaawctcj5y6fbyozezt725azs3cvmlmnrpxghg3ny2dflkeayz2oqla
+    ap-mumbai-1    = ocid1.image.oc1.ap-mumbai-1.aaaaaaaasyycr7ps55lrah6a7a2xxtqifvgarhwuf6u73hwup4zkw7f4kn5a
+    ap-osaka-1     = ocid1.image.oc1.ap-osaka-1.aaaaaaaapenyex5pxfxy6sj3y3giodvcuab3q2ijecseqagxrjkh56nfp3bq
+    ap-seoul-1     = ocid1.image.oc1.ap-seoul-1.aaaaaaaauz3wjiq7cug667vvj7rsghqam7k6ixvq64deiw2suf6mk2iru5eq
+    ap-sydney-1    = ocid1.image.oc1.ap-sydney-1.aaaaaaaabrw3swos5hvtxqfgxu63bnd23hfjq7telribqeiqusxtdazwlwua
+    ap-tokyo-1     = ocid1.image.oc1.ap-tokyo-1.aaaaaaaa3xvdaubabxqrh36zgujjp3gh6c2suul4u4nrchpnvf4hbggwgodq
+    ca-montreal-1  = ocid1.image.oc1.ca-montreal-1.aaaaaaaanrbycrwfxq73bnb4riglp7e67gb6xjatpkke5h2c6pdwcblb7rja
+    ca-toronto-1   = ocid1.image.oc1.ca-toronto-1.aaaaaaaa2mwnn3au2xesuaplssp37bwnym3mb6va6rz5gbfgpxvt3ls6dbqa
+    eu-amsterdam-1 = ocid1.image.oc1.eu-amsterdam-1.aaaaaaaaxaf3xlj46q2jc4e3cdiqrpt3oacavie6ersr766sqafyex2qh5lq
+    eu-frankfurt-1 = ocid1.image.oc1.eu-frankfurt-1.aaaaaaaasso5vqvbonl4ne6lz4ugpazyc6g3gll6pi2kucjxtxt3rul4l3sa
+    eu-zurich-1    = ocid1.image.oc1.eu-zurich-1.aaaaaaaavcfqtutpkkoyoxgmcomcbtlonsd3so2drrbk4hainibyp5ruxnea
+    me-dubai-1     = ocid1.image.oc1.me-dubai-1.aaaaaaaacc4knywj5cmo544357zb2yn6fabmarv6s3khyny22spuq4edm4iq
+    me-jeddah-1    = ocid1.image.oc1.me-jeddah-1.aaaaaaaaehhthiygczhamsxpnaebwwuuof4ghuzbhmtl5yfcjzw7af6lwlgq
+    sa-santiago-1  = ocid1.image.oc1.sa-santiago-1.aaaaaaaaghwg2p3fwtu4q25p5ebg65mf5ncqbikqrepsttnzqrtwzccrdcma
+    sa-saopaulo-1  = ocid1.image.oc1.sa-saopaulo-1.aaaaaaaa2bfgkwh4ajxq573nfzqk6pzcnamhz7yecg7qjwjlstbtkdiaovxq
+    uk-cardiff-1   = ocid1.image.oc1.uk-cardiff-1.aaaaaaaanivgefpi7h2yap5e2st7setz6bri2pfen2nttwdy3n6eyliknqla
+    uk-london-1    = ocid1.image.oc1.uk-london-1.aaaaaaaaaqhrhabecnuwgasrfagihh5nqkexc7mq6lwwv5nvsxmu3gajp2ta
+    us-ashburn-1   = ocid1.image.oc1.iad.aaaaaaaacliktmviofdyzhua77nyur2htmrzwjaxollbfae52q6zfuvkcjdq
+    us-langley-1   = ocid1.image.oc2.us-langley-1.aaaaaaaak5z3civ5tdlntkjivu7bmez5zngg3m6zd24qcfmn43btptzob3lq
+    us-luke-1      = ocid1.image.oc2.us-luke-1.aaaaaaaaq5mfm7tle2a2nnysg3cfngbdqlkelg6rdwmkinqgnkhy7fgzrg6q
+    us-phoenix-1   = ocid1.image.oc1.phx.aaaaaaaaiz72kdaznhk3kynsw4faync6z3ibd3en6vchupnb4vonfsnvizwq
+    us-sanjose-1   = ocid1.image.oc1.us-sanjose-1.aaaaaaaaxyaxpb7mkld7dsoqibdbg2na5npgzkjn3oybqifzmcaki7qewwfq
   }
 }
 


### PR DESCRIPTION
While the vast majority of regions use AD=1, several use AD=3 so this should map the correct availability domain to the region entered in terraform.tfvars. Source: [Regions and Availability Domains](https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm)